### PR TITLE
Fix timezone-induced off-by-one in date URLs and display

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -2,6 +2,7 @@
 import Tag from "@components/Tag.astro";
 import TypeLabel from "@components/TypeLabel.astro";
 import { getContentPreview } from "@utils/text";
+import { buildLogUrl } from "@utils/markdownEndpoints";
 import type { CollectionEntry } from "astro:content";
 import { Icon } from "astro-icon/components";
 
@@ -28,15 +29,15 @@ const date = new Date(
         : (post.data as any).publishedAt || (post.data as any).createdAt,
 );
 
-// Format date components
-const year = date.getFullYear();
-const month = String(date.getMonth() + 1).padStart(2, "0");
-const day = String(date.getDate()).padStart(2, "0");
+// Format date components using UTC to avoid timezone offset issues
+const year = date.getUTCFullYear();
+const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+const day = String(date.getUTCDate()).padStart(2, "0");
 
 // Build URL and formatted date
 let url: string;
 if (type === "log") {
-    url = `/logs/${year}/${month}/${day}`;
+    url = buildLogUrl(post.id);
 } else if (post.collection === "til") {
     const category = post.id.split('/')[0];
     const slug = post.id.split('/').slice(1).join('/').replace(/\.(md|mdx)$/, '');

--- a/src/pages/logs.md.ts
+++ b/src/pages/logs.md.ts
@@ -16,7 +16,7 @@ export const GET: APIRoute = async () => {
       ); // Show all logs
     // Get all years with logs
     const yearsWithLogs = [
-      ...new Set(logs.map((log) => new Date(log.data.date).getFullYear())),
+      ...new Set(logs.map((log) => new Date(log.data.date).getUTCFullYear())),
     ].sort((a, b) => b - a);
 
     let content = `# Logs
@@ -29,7 +29,7 @@ Daily logs and thoughts.
 
     yearsWithLogs.forEach((year) => {
       const yearLogs = logs.filter(
-        (log) => new Date(log.data.date).getFullYear() === year
+        (log) => new Date(log.data.date).getUTCFullYear() === year
       );
       content += `- [${year}](/logs/${year}/index.md) (${yearLogs.length} entries)\n`;
     });

--- a/src/pages/logs/[year].astro
+++ b/src/pages/logs/[year].astro
@@ -9,7 +9,7 @@ import Breadcrumbs from "@components/Breadcrumbs.astro";
 export async function getStaticPaths() {
   const logs = await getCollection("logs", ({ data }) => !data.draft);
   const years = [
-    ...new Set(logs.map((log) => new Date(log.data.date).getFullYear())),
+    ...new Set(logs.map((log) => new Date(log.data.date).getUTCFullYear())),
   ];
 
   return years.map((year) => ({
@@ -22,13 +22,13 @@ const { year } = Astro.params;
 const logs = await getCollection("logs", ({ data }) => !data.draft);
 
 const yearLogs = logs
-  .filter((log) => new Date(log.data.date).getFullYear().toString() === year)
+  .filter((log) => new Date(log.data.date).getUTCFullYear().toString() === year)
   .sort(
     (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
   );
 
 // Get all years with logs for navigation
-const yearsWithLogs = [...new Set(logs.map((log) => new Date(log.data.date).getFullYear()))].sort((a, b) => b - a);
+const yearsWithLogs = [...new Set(logs.map((log) => new Date(log.data.date).getUTCFullYear()))].sort((a, b) => b - a);
 const currentYearIndex = yearsWithLogs.indexOf(parseInt(year));
 const prevYear = currentYearIndex < yearsWithLogs.length - 1 ? yearsWithLogs[currentYearIndex + 1] : null;
 const nextYear = currentYearIndex > 0 ? yearsWithLogs[currentYearIndex - 1] : null;
@@ -36,7 +36,7 @@ const nextYear = currentYearIndex > 0 ? yearsWithLogs[currentYearIndex - 1] : nu
 // Group logs by month
 const logsByMonth = yearLogs.reduce(
   (acc, log) => {
-    const month = new Date(log.data.date).getMonth();
+    const month = new Date(log.data.date).getUTCMonth();
     if (!acc[month]) {
       acc[month] = [];
     }

--- a/src/pages/logs/[year]/[month].astro
+++ b/src/pages/logs/[year]/[month].astro
@@ -13,8 +13,8 @@ export async function getStaticPaths() {
   const yearMonths = new Set<string>();
   logs.forEach((log) => {
     const date = new Date(log.data.date);
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
     yearMonths.add(`${year}-${month}`);
   });
 
@@ -33,7 +33,7 @@ const logs = await getCollection("logs", ({ data }) => !data.draft);
 const monthLogs = logs
   .filter((log) => {
     const date = new Date(log.data.date);
-    return date.getFullYear() === year && date.getMonth() + 1 === month;
+    return date.getUTCFullYear() === year && date.getUTCMonth() + 1 === month;
   })
   .sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
 
@@ -47,7 +47,7 @@ const monthName = monthNames[month - 1];
 // Create a map of days with logs
 const daysWithLogs = new Map<number, typeof logs[0]>();
 monthLogs.forEach(log => {
-  const day = new Date(log.data.date).getDate();
+  const day = new Date(log.data.date).getUTCDate();
   daysWithLogs.set(day, log);
 });
 
@@ -86,8 +86,8 @@ if (currentWeek.length > 0) {
 const monthsWithLogs = new Set<string>();
 logs.forEach((log) => {
   const date = new Date(log.data.date);
-  const logYear = date.getFullYear();
-  const logMonth = date.getMonth() + 1;
+  const logYear = date.getUTCFullYear();
+  const logMonth = date.getUTCMonth() + 1;
   monthsWithLogs.add(`${logYear}-${String(logMonth).padStart(2, '0')}`);
 });
 

--- a/src/pages/logs/[year]/[month]/index.md.ts
+++ b/src/pages/logs/[year]/[month]/index.md.ts
@@ -10,8 +10,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const yearMonths = new Set<string>();
   logs.forEach((log) => {
     const date = new Date(log.data.date);
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
     yearMonths.add(`${year}-${month}`);
   });
 
@@ -39,8 +39,8 @@ export const GET: APIRoute = async ({ params }) => {
       .filter((log) => {
         const date = new Date(log.data.date);
         return (
-          date.getFullYear() === yearNumber &&
-          date.getMonth() + 1 === monthNumber
+          date.getUTCFullYear() === yearNumber &&
+          date.getUTCMonth() + 1 === monthNumber
         );
       })
       .sort(
@@ -78,7 +78,7 @@ ${monthLogs.length} ${monthLogs.length === 1 ? 'entry' : 'entries'}
     // Group by day
     const logsByDay = monthLogs.reduce(
       (acc, log) => {
-        const day = new Date(log.data.date).getDate();
+        const day = new Date(log.data.date).getUTCDate();
         if (!acc[day]) {
           acc[day] = [];
         }

--- a/src/pages/logs/[year]/index.md.ts
+++ b/src/pages/logs/[year]/index.md.ts
@@ -7,7 +7,7 @@ export const prerender = true;
 export const getStaticPaths: GetStaticPaths = async () => {
   const logs = await getCollection('logs');
   const years = [
-    ...new Set(logs.map((log) => new Date(log.data.date).getFullYear())),
+    ...new Set(logs.map((log) => new Date(log.data.date).getUTCFullYear())),
   ];
 
   return years.map((year) => ({
@@ -26,7 +26,7 @@ export const GET: APIRoute = async ({ params }) => {
 
     const yearLogs = logs
       .filter(
-        (log) => new Date(log.data.date).getFullYear().toString() === year
+        (log) => new Date(log.data.date).getUTCFullYear().toString() === year
       )
       .sort(
         (a, b) =>
@@ -36,7 +36,7 @@ export const GET: APIRoute = async ({ params }) => {
     // Group logs by month
     const logsByMonth = yearLogs.reduce(
       (acc, log) => {
-        const month = new Date(log.data.date).getMonth();
+        const month = new Date(log.data.date).getUTCMonth();
         if (!acc[month]) {
           acc[month] = [];
         }

--- a/src/pages/posts.md.ts
+++ b/src/pages/posts.md.ts
@@ -17,7 +17,7 @@ export const GET: APIRoute = async () => {
     // Get all years with posts
     const yearsWithPosts = [
       ...new Set(
-        posts.map((post) => new Date(post.data.createdAt).getFullYear())
+        posts.map((post) => new Date(post.data.createdAt).getUTCFullYear())
       ),
     ].sort((a, b) => b - a);
 
@@ -31,7 +31,7 @@ Long-form articles and essays.
 
     yearsWithPosts.forEach((year) => {
       const yearPosts = posts.filter(
-        (post) => new Date(post.data.createdAt).getFullYear() === year
+        (post) => new Date(post.data.createdAt).getUTCFullYear() === year
       );
       content += `- [${year}](/posts/${year}/index.md) (${yearPosts.length} ${yearPosts.length === 1 ? 'post' : 'posts'})\n`;
     });

--- a/src/pages/posts/[...page].astro
+++ b/src/pages/posts/[...page].astro
@@ -27,7 +27,7 @@ const publishedPosts = allPosts.filter(
 );
 const yearsWithPosts = [
   ...new Set(
-    publishedPosts.map((post) => new Date(post.data.createdAt).getFullYear()),
+    publishedPosts.map((post) => new Date(post.data.createdAt).getUTCFullYear()),
   ),
 ].sort((a, b) => b - a);
 

--- a/src/pages/posts/[year].astro
+++ b/src/pages/posts/[year].astro
@@ -10,7 +10,7 @@ export async function getStaticPaths() {
     const posts = await getCollection("posts", ({ data }) => !data.draft);
     const years = [
         ...new Set(
-            posts.map((post) => new Date(post.data.createdAt).getFullYear()),
+            posts.map((post) => new Date(post.data.createdAt).getUTCFullYear()),
         ),
     ];
 
@@ -27,12 +27,12 @@ const posts = await getCollection(collection, ({ data }) => !data.draft);
 const yearPosts = posts
     .filter(
         (post) =>
-            new Date(post.data.createdAt).getFullYear().toString() === year,
+            new Date(post.data.createdAt).getUTCFullYear().toString() === year,
     )
     .sort((a, b) => b.data.createdAt.valueOf() - a.data.createdAt.valueOf());
 
 // Get all years with posts for navigation
-const yearsWithPosts = [...new Set(posts.map((post) => new Date(post.data.createdAt).getFullYear()))].sort((a, b) => b - a);
+const yearsWithPosts = [...new Set(posts.map((post) => new Date(post.data.createdAt).getUTCFullYear()))].sort((a, b) => b - a);
 const currentYearIndex = yearsWithPosts.indexOf(parseInt(year));
 const prevYear = currentYearIndex < yearsWithPosts.length - 1 ? yearsWithPosts[currentYearIndex + 1] : null;
 const nextYear = currentYearIndex > 0 ? yearsWithPosts[currentYearIndex - 1] : null;

--- a/src/pages/posts/[year]/index.md.ts
+++ b/src/pages/posts/[year]/index.md.ts
@@ -8,7 +8,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const posts = await getCollection('posts', ({ data }) => !data.draft);
   const years = [
     ...new Set(
-      posts.map((post) => new Date(post.data.createdAt).getFullYear())
+      posts.map((post) => new Date(post.data.createdAt).getUTCFullYear())
     ),
   ];
 
@@ -29,7 +29,7 @@ export const GET: APIRoute = async ({ params }) => {
     const yearPosts = posts
       .filter(
         (post) =>
-          new Date(post.data.createdAt).getFullYear().toString() === year
+          new Date(post.data.createdAt).getUTCFullYear().toString() === year
       )
       .sort((a, b) => b.data.createdAt.valueOf() - a.data.createdAt.valueOf());
 
@@ -44,7 +44,7 @@ ${yearPosts.length} ${yearPosts.length === 1 ? 'post' : 'posts'}
     // Group posts by month
     const postsByMonth = yearPosts.reduce(
       (acc, post) => {
-        const month = new Date(post.data.createdAt).getMonth();
+        const month = new Date(post.data.createdAt).getUTCMonth();
         if (!acc[month]) {
           acc[month] = [];
         }


### PR DESCRIPTION
## Summary
- Replace all local JS date methods (`getFullYear`, `getMonth`, `getDate`) with UTC equivalents (`getUTCFullYear`, `getUTCMonth`, `getUTCDate`) across 10 files
- Fixes tag pages and log listings showing wrong dates and generating 404 URLs (e.g., `/logs/2026/03/02` instead of `/logs/2026/03/01`)
- PostCard component now uses the existing `buildLogUrl()` utility for log URLs instead of manual date string construction

## Root cause
Dates stored as `2026-03-01` (midnight UTC) were being parsed with local timezone methods. When the server timezone is behind UTC, the local date shifts back one day, producing incorrect URLs and display dates.

## Test plan
- [ ] Verify `/tags/tomo/` page shows correct date (2026-03-01) and working link to `/logs/2026/03/01`
- [ ] Spot-check other tag pages for correct date/URL alignment
- [ ] Verify log month calendar pages still route correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)